### PR TITLE
Refine Deno-based Next.js setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Deno Next.js Demo
+
+This repository contains a minimal Next.js application written in TypeScript. It is configured to run using **Deno** rather than Node. The site advertises freelance video creation and editing services and demonstrates Tailwind CSS styling.
+
+## Running locally
+
+1. Install [Deno](https://deno.land/).
+2. Change into the `next-app` directory and start the dev server:
+
+   ```bash
+   deno task dev
+   ```
+
+Deno will download the required packages on first run. Once complete the site will be available at <http://localhost:3000>.

--- a/next-app/README.md
+++ b/next-app/README.md
@@ -1,0 +1,22 @@
+# Freelance Video Creation & Editing Site
+
+This Next.js project runs entirely with **Deno**. No `npm install` step is needed because dependencies are imported via npm specifiers and fetched automatically by Deno on first run. Tailwind CSS is configured for styling and the site contains a few pages describing freelance video services.
+
+## Development
+
+1. Install [Deno](https://deno.land/).
+2. Start the dev server:
+
+   ```
+   deno task dev
+   ```
+
+## Production build
+
+To generate an optimized build and start it locally:
+
+```bash
+deno task build
+deno task start
+```
+

--- a/next-app/components/Layout.tsx
+++ b/next-app/components/Layout.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from 'react';
+import Link from 'next/link';
+import '../styles/globals.css';
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <header className="bg-gray-800 text-white p-4">
+        <nav className="space-x-4">
+          <Link href="/" className="hover:underline">Home</Link>
+          <Link href="/services" className="hover:underline">Services</Link>
+          <Link href="/about" className="hover:underline">About</Link>
+          <Link href="/contact" className="hover:underline">Contact</Link>
+        </nav>
+      </header>
+      <main className="flex-grow container mx-auto p-4">
+        {children}
+      </main>
+      <footer className="bg-gray-200 text-center p-4">
+        &copy; 2025 Freelance Video Creation & Editing
+      </footer>
+    </div>
+  );
+}

--- a/next-app/deno.json
+++ b/next-app/deno.json
@@ -1,0 +1,10 @@
+{
+  "tasks": {
+    "dev": "deno run -A main.ts",
+    "start": "deno run -A main.ts",
+    "build": "deno run -A npm:next@13.4.12 build"
+  },
+  "imports": {
+    "npm:": "https://esm.sh/"
+  }
+}

--- a/next-app/main.ts
+++ b/next-app/main.ts
@@ -1,0 +1,14 @@
+import next from 'npm:next@13.4.12';
+import { createServer } from 'node:http';
+
+const dev = Deno.env.get('NODE_ENV') !== 'production';
+const app = next({ dev });
+const handle = app.getRequestHandler();
+
+await app.prepare();
+
+createServer((req, res) => {
+  handle(req, res);
+}).listen(3000, () => {
+  console.log('> Ready on http://localhost:3000');
+});

--- a/next-app/next-env.d.ts
+++ b/next-app/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next-app/next.config.js
+++ b/next-app/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  swcMinify: true,
+};
+
+export default nextConfig;

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "freelance-video",
+  "private": true
+}

--- a/next-app/pages/_app.tsx
+++ b/next-app/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/next-app/pages/about.tsx
+++ b/next-app/pages/about.tsx
@@ -1,0 +1,14 @@
+import Layout from '../components/Layout';
+import Head from 'next/head';
+
+export default function About() {
+  return (
+    <Layout>
+      <Head>
+        <title>About - Freelance Video</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">About Me</h1>
+      <p>I am a freelance video creator and editor with years of experience crafting compelling stories.</p>
+    </Layout>
+  );
+}

--- a/next-app/pages/contact.tsx
+++ b/next-app/pages/contact.tsx
@@ -1,0 +1,14 @@
+import Layout from '../components/Layout';
+import Head from 'next/head';
+
+export default function Contact() {
+  return (
+    <Layout>
+      <Head>
+        <title>Contact - Freelance Video</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">Contact</h1>
+      <p>Email me at <a href="mailto:video@example.com" className="text-blue-600 underline">video@example.com</a></p>
+    </Layout>
+  );
+}

--- a/next-app/pages/index.tsx
+++ b/next-app/pages/index.tsx
@@ -1,0 +1,15 @@
+import Layout from '../components/Layout';
+import Head from 'next/head';
+
+export default function Home() {
+  return (
+    <Layout>
+      <Head>
+        <title>Freelance Video Services</title>
+      </Head>
+      <h1 className="text-3xl font-bold mb-4">Professional Video Creation & Editing</h1>
+      <p className="mb-2">I offer high quality video production and editing services for businesses and individuals.</p>
+      <p>Contact me to bring your ideas to life!</p>
+    </Layout>
+  );
+}

--- a/next-app/pages/services.tsx
+++ b/next-app/pages/services.tsx
@@ -1,0 +1,19 @@
+import Layout from '../components/Layout';
+import Head from 'next/head';
+
+export default function Services() {
+  return (
+    <Layout>
+      <Head>
+        <title>Services - Freelance Video</title>
+      </Head>
+      <h1 className="text-2xl font-bold mb-4">Services</h1>
+      <ul className="list-disc pl-5 space-y-2">
+        <li>Promo and marketing videos</li>
+        <li>Event coverage and editing</li>
+        <li>Social media clips</li>
+        <li>Product demos</li>
+      </ul>
+    </Layout>
+  );
+}

--- a/next-app/postcss.config.js
+++ b/next-app/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/next-app/styles/globals.css
+++ b/next-app/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/next-app/tailwind.config.js
+++ b/next-app/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/next-app/tsconfig.json
+++ b/next-app/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["deno.ns"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add repo-level README with basic run instructions
- simplify next-app package.json to avoid npm scripts
- expand next-app README with Deno-only workflow
- add build/start tasks to deno.json

## Testing
- `deno task dev` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686979406560832fbbc37995bc1073d4